### PR TITLE
Exclude `Cranky.toml` from package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 authors = ["Eric Seppanen <eds@reric.net>"]
 readme = "README.md"
 edition = "2018"
+exclude = ["Cranky.toml"]
 
 [dependencies]
 rustversion = "1.0"


### PR DESCRIPTION
The Cranky config file shouldn't be included in the package as it's only used for during development.