### PR TITLE
Make rustversion a dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 exclude = ["Cranky.toml"]
 
-[dependencies]
+[dev-dependencies]
 rustversion = "1.0"
 
 [package.metadata.release]


### PR DESCRIPTION
It's only used in tests, so this is sufficient and avoids an unnecessary transitive dependency for users of escape8529.